### PR TITLE
Referrer URL placeholders in the destination folder

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -38,7 +38,19 @@ rulesets['referrer'] = function(downloadItem, suggest) {
 		var ref_domain = matches && matches[1].replace(/^www\./i, '');
 
 		if(ref_map[ref_domain]) {
-			suggest({ filename: ref_map[ref_domain] + downloadItem.filename });
+            var suggestion = ref_map[ref_domain];
+            if (suggestion.match("{(pathsegment[1-9]|hostname)}")) {
+                var referrerUrl = new URL(downloadItem.referrer);
+                suggestion = suggestion.replace("{hostname}", referrerUrl.hostname);
+                var pathSegments = referrerUrl.pathname ? referrerUrl.pathname.split('/') : [];
+                pathSegments = pathSegments.filter(function(segment) {
+                    return segment ? true : false
+                });
+                pathSegments.forEach(function(segment, index) {
+                    suggestion = segment ? suggestion.replace("{pathsegment" + ++index + "}", decodeURIComponent(segment)) : suggestion;
+                });
+            }
+            suggest({filename: suggestion + downloadItem.filename});
 			return true;
 		}
 	}

--- a/src/options.html
+++ b/src/options.html
@@ -198,6 +198,7 @@
 					</table>
 					<ul class="note">
 						<li>Do not include http:// or www. Other subdomains, such as images.domain.com, <strong>are</strong> required.</li>
+						<li>You can refer to parts of the referrer URL using {hostname} and {pathsegment[1-9]}, this is independent of the matched referrer URL. Path segments are URL decoded. E.g. for a referrer of example.com/articles/user%20uploads and a destination folder of {hostname}/{pathsegment2} the suggested download folder would be example.com/user uploads</li>
 						<li>Larger websites often utilize Content Distribution Networks, which means that the referrer for a certain image might not be the same as the domain of the website you are visiting. Facebook, for instance, uses the Akamai network to serve images.</li>
 					</ul>
 


### PR DESCRIPTION
Hi, I started to use your plugin and found it really helpful, but I wanted the referrer mapping to be a bit more dynamic, so I created this pull request. Hope you find it helpful, would love to be able to go back to the webstore version instead of my dev plugin. Cheers, Christoffer

Allow to use placeholders in the destination folder for referrer mappings. Possible placeholders are {hostname} and {pathsegment[1-9]}, these refer back to the hostname part of the referrer URL (see URL JavaScript class) and tokenize the pathname of the referrer URL.
