### PR TITLE
Chrome Manifest V3 migration (permissions, local storage, async) + optional debugging support.

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -1,0 +1,12 @@
+{
+	"appName": {
+		"message": "Downloads Router"
+	},
+	"appDesc": {
+		"message": "Zajišťuje automatické směrování souborů do lokálních složek při stahování."
+	},
+
+	"msg_saved": {
+		"message": "Nastavení uloženo."
+	}
+}

--- a/src/manager.js
+++ b/src/manager.js
@@ -6,6 +6,7 @@ var installedVersion = null;
 var dr_order = null;
 var filename_map;
 var ref_map;
+var uriPath_map;
 var mime_map;
 var dr_global_ref_folders;
 var dr_global_debugging = false;
@@ -88,6 +89,27 @@ rulesets.referrer = function(downloadItem, suggest) {
 	return false;
 };
 
+rulesets.uriPath = function(downloadItem, suggest) {
+	customLog('rulesets.uriPath():: begin');
+
+	var keys = Object.keys(uriPath_map);
+	if(keys.length) {
+		var idx, regex, matches;
+		for(idx = 0; idx < keys.length; idx++) {
+			regex   = new RegExp(keys[idx], 'i');
+			matches = regex.exec(downloadItem.url);
+			if(matches) {
+				suggest({ filename: uriPath_map[keys[idx]] + downloadItem.filename });
+				customLog('rulesets.uriPath():: suggest: ' + uriPath_map[keys[idx]] + downloadItem.filename);
+				return true;
+			}
+		}
+	}
+
+	customLog('rulesets.uriPath():: no suggest');
+	return false;
+};
+
 rulesets.mime = function(downloadItem, suggest) {
 	customLog('rulesets.mime():: begin');
 	var mime_type = downloadItem.mime;    
@@ -162,6 +184,11 @@ async function asyncProcess(downloadItem, suggest) {
 	} else {
 		mime_map = [];
 	}
+	if (storageCache.dr_uriPath_map) {
+		uriPath_map  = JSON.parse(storageCache.dr_uriPath_map);
+	} else {
+		uriPath_map = [];
+	}
 
 	dr_global_ref_folders = storageCache.dr_global_ref_folders;
 	if (!dr_global_ref_folders) {
@@ -216,7 +243,7 @@ function initMain() {
 function initMainCallback() {
 	if (!dr_order) {
 		// initialize
-		dr_order = ['filename', 'referrer', 'mime'];
+		dr_order = ['filename', 'uriPath', 'referrer', 'mime'];
 		chrome.storage.local.set({'dr_order': dr_order});
 	}
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -1,12 +1,45 @@
-var order    = JSON.parse(localStorage.getItem('dr_order'));
-var rulesets = {};
+/*jshint esversion: 6 */
 
-if(!order) { 
-	order = ['filename', 'referrer', 'mime'];
+var rulesets = {};
+var installedVersion = null;
+
+var dr_order = null;
+var filename_map;
+var ref_map;
+var mime_map;
+var dr_global_ref_folders;
+var dr_global_debugging = false;
+
+function customLog(msg) {
+	if (!dr_global_debugging) {
+		return;
+	}
+	console.log(msg);
 }
 
-rulesets['filename'] = function(downloadItem, suggest) {
-	filename_map = JSON.parse(localStorage.getItem('dr_filename_map'));
+// Reads all data out of storage.local and exposes it via a promise.
+//
+// Note: Once the Storage API gains promise support, this function
+// can be greatly simplified.
+function getAllStorageLocalData() {
+  // Immediately return a promise and start asynchronous work
+  return new Promise((resolve, reject) => {
+    // Asynchronously fetch all data from storage.local.
+    chrome.storage.local.get(null, (items) => {
+      // Pass any observed errors down the promise chain.
+      if (chrome.runtime.lastError) {
+        return reject(chrome.runtime.lastError);
+      }
+      // Pass the data retrieved from storage down the promise chain.
+      customLog('getAllStorageLocalData():: loading1');
+      resolve(items);
+      customLog('getAllStorageLocalData():: loading2');
+    });
+  });
+}
+
+rulesets.filename = function(downloadItem, suggest) {
+	customLog('rulesets.filename():: begin');
 
 	var keys = Object.keys(filename_map);
 	if(keys.length) {
@@ -16,44 +49,48 @@ rulesets['filename'] = function(downloadItem, suggest) {
 			matches = regex.exec(downloadItem.filename);
 			if(matches) {
 				suggest({ filename: filename_map[keys[idx]] + downloadItem.filename });
+				customLog('rulesets.filename():: suggest: ' + filename_map[keys[idx]] + downloadItem.filename);
 				return true;
 			}
 		}
 	}
 
+	customLog('rulesets.filename():: no suggest');
 	return false;
-}
+};
 
-rulesets['referrer'] = function(downloadItem, suggest) {
-	ref_map = JSON.parse(localStorage.getItem('dr_referrer_map'));
+rulesets.referrer = function(downloadItem, suggest) {
+	customLog('rulesets.referrer():: begin');
+	var matches;
+	if(downloadItem.referrer) {
+		matches = downloadItem.referrer.match(/^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i);
+	} else {
+		matches = downloadItem.url.match(/^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i);
+	}
 
-	if(Object.keys(ref_map).length) {
-		var matches;
-		if(downloadItem.referrer) {
-			matches    = downloadItem.referrer.match(/^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i);
-		} else {
-			matches = downloadItem.url.match(/^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i);
-		}
+	var ref_domain = matches && matches[1].replace(/^www\./i, '');
 
-		var ref_domain = matches && matches[1].replace(/^www\./i, '');
-
+	if (Object.keys(ref_map).length) {
 		if(ref_map[ref_domain]) {
 			suggest({ filename: ref_map[ref_domain] + downloadItem.filename });
+			customLog('rulesets.referrer():: mapping suggest: ' + ref_map[ref_domain] + downloadItem.filename);
 			return true;
 		}
 	}
 
-	if(JSON.parse(localStorage.getItem('dr_global_ref_folders'))) {
+	if (dr_global_ref_folders) {
 		suggest({ filename: ref_domain + '/' + downloadItem.filename });
+		customLog('rulesets.referrer():: global referrer suggest: ' + ref_domain + '/' + downloadItem.filename);
 		return true;
 	}
 
+	customLog('rulesets.referrer():: no suggest');
 	return false;
-}
+};
 
-rulesets['mime'] = function(downloadItem, suggest) {
-	mime_map  = JSON.parse(localStorage.getItem('dr_mime_map'));
-	mime_type = downloadItem.mime;    
+rulesets.mime = function(downloadItem, suggest) {
+	customLog('rulesets.mime():: begin');
+	var mime_type = downloadItem.mime;    
 
 	// Octet-stream workaround
 	if(mime_type == 'application/octet-stream') {
@@ -75,33 +112,121 @@ rulesets['mime'] = function(downloadItem, suggest) {
 		}
 	}
 
-	folder = mime_map[mime_type];
+	var folder = mime_map[mime_type];
 	if(folder) {
 		suggest({ filename: folder + downloadItem.filename });
+		customLog('rulesets.mime():: suggest: ' + folder + downloadItem.filename);
 		return true;
 	}
 
+	customLog('rulesets.mime():: no suggest');
 	return false;
-}
+};
 
+async function asyncProcess(downloadItem, suggest) {
+	customLog('asyncProcess():: begin');
+	// Where we will expose all the data we retrieve from storage.local.
+	var storageCache = {};
 
+	// Asynchronously retrieve data from storage.local, then cache it.
+	let initStorageCache = getAllStorageLocalData().then(items => {
+		// Copy the data retrieved from storage into storageCache.
+		customLog('asyncProcess():: loading configuration');
+		Object.assign(storageCache, items);
+		customLog('asyncProcess():: configuration loaded');
+	});
 
-chrome.downloads.onDeterminingFilename.addListener(function(downloadItem, suggest) {
+	try {
+		await initStorageCache;
+	} catch (e) {
+		// Handle error that occurred during storage initialization.
+	}
+
+	// Normal action handler logic.
+	customLog('asyncProcess():: main processing');
+	customLog('loaded configuration: ' + storageCache);
+	dr_order = storageCache.dr_order;
+
+	if (storageCache.dr_filename_map) {
+		filename_map = JSON.parse(storageCache.dr_filename_map);
+	} else {
+		filename_map = [];
+	}
+	if (storageCache.dr_referrer_map) {
+		ref_map = JSON.parse(storageCache.dr_referrer_map);
+	} else {
+		ref_map = [];
+	}
+	if (storageCache.dr_mime_map) {
+		mime_map  = JSON.parse(storageCache.dr_mime_map);
+	} else {
+		mime_map = [];
+	}
+
+	dr_global_ref_folders = storageCache.dr_global_ref_folders;
+	if (!dr_global_ref_folders) {
+		dr_global_ref_folders = false;
+	}
+
+	// global_debugging
+	dr_global_debugging = storageCache.dr_global_debugging;
+	if (!dr_global_debugging) {
+		dr_global_debugging = false;
+	}
+
+	customLog('asyncProcess():: maps processing');
 	var done = false;
-
-	order.every(function(idx) {
+	dr_order.every(function(idx) {
 		done = rulesets[idx](downloadItem, suggest);
+		customLog('index '+idx+' returned '+done);
 		if(done) {
 			return false;
 		}
 		return true;
 	});
+	if (!done) {
+		// https://developer.chrome.com/docs/extensions/reference/downloads/#event-onDeterminingFilename
+		// ...The DownloadItem will not complete until all listeners have called suggest.
+		// ...Listeners may call suggest without any arguments in order to allow the download to use downloadItem.filename for its filename.
+		suggest();
+		customLog('asyncProcess():: no overall suggestion');
+	}
+
+	customLog('asyncProcess():: finished');
+}
+
+chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
+	customLog('listener begin');
+	asyncProcess(downloadItem, suggest);
+	customLog('listener end');
+	// https://developer.chrome.com/docs/extensions/reference/downloads/#event-onDeterminingFilename
+	// If the listener calls suggest asynchronously, then it must return true.
+	return true;
 });
 
-var version = localStorage.getItem('dr_version');
+function initMain() {
+    chrome.storage.local.get(['dr_order', 'dr_version'], function(items) {
+			dr_order = items.dr_order;
+			installedVersion = items.dr_version;
 
-if(!version || version != chrome.runtime.getManifest().version) {
-	// Open the options page directly after installing or updating the extension
-	chrome.tabs.create({ url: "options.html" });
-	localStorage.setItem('dr_version', chrome.runtime.getManifest().version);
+			initMainCallback();
+	});
 }
+
+function initMainCallback() {
+	if (!dr_order) {
+		// initialize
+		dr_order = ['filename', 'referrer', 'mime'];
+		chrome.storage.local.set({'dr_order': dr_order});
+	}
+
+	let manifestVersion = chrome.runtime.getManifest().version;
+
+	if(!installedVersion || installedVersion != manifestVersion) {
+		// Open the options page directly after installing or updating the extension
+		chrome.tabs.create({ url: "options.html" });
+		chrome.storage.local.set({'dr_version': manifestVersion});
+	}
+}
+
+initMain();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 
 	"name": "__MSG_appName__",
 	"short_name": "DLRouter",
@@ -11,12 +11,11 @@
 	"homepage_url": "https://bitbucket.org/lfk/downloads-router-chrome-extension",
 
 	"permissions": [
-		"downloads"
+		"downloads", "tabs", "storage"
 	],
 
 	"background": {
-		"scripts": ["manager.js"],
-		"persistent": false
+		"service_worker": "manager.js"
 	},
 
 	"icons": {

--- a/src/options.html
+++ b/src/options.html
@@ -153,6 +153,7 @@
 
 			<div id="news">
 				<p><strong>(v0.8.1) Sept. 30, 2014:</strong> Bug fixes and fallback cases for referrer- and MIME-rules.</p>
+				<p><strong>July 07, 2021:</strong> Chrome Manifest V3 migration. Console output support added (debug messages).</p>
 			</div>
 
 			<ul id="nav">
@@ -212,6 +213,14 @@
 					</table>
 					<p class="note">* Keywords are case-insensitive. Recommended basic usage is a single keyword per rule. Further guidelines are available on the "Usage instructions" page. The keyword is treated directly as a regular expression &mdash; feel free to experiment.</p>
 
+					<h2>Troubleshooting</h2>
+
+					<div style="margin: 5px; padding: 10px; border: 1px solid #efefef; background-color: #fafafa;">
+						<input type="checkbox" name="" id="global_debugging" value="1">  
+						<h5 style="display: inline-block; margin: 0;"><label for="global_debugging">Enable debugging</label></h5>
+						<p class="note">Enable this checkbox to start logging debug messages to extension's console output (extension detail / Inspect views / service worker).</p>
+					</div>
+
 					<button id="save" class="btn2">&#10004; Save configuration</button>
 
 					<h2>Common MIME types</h2>
@@ -250,7 +259,7 @@
 					You may manually circumvent this restriction by creating a "symbolic link" (<a href="http://www.howtogeek.com/howto/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/">more info</a>)
 					from within the downloads directory to any other direction on your harddrive(s).</p>
 
-					<h3>Symlinks on Windows (XP, Vista, 7, 8)</h3>
+					<h3>Symlinks on Windows (XP, Vista, 7, 8, 10)</h3>
 
 					<ol>
 						<li>Open the command prompt (cmd.exe) as Administrator<br><em>Search for cmd in the start menu, right-click and choose 'Run as Administrator'</em></li>

--- a/src/options.html
+++ b/src/options.html
@@ -168,8 +168,8 @@
 					Destinations must be located within the base downloads folder; use symbolic links to circumvent this restriction (see usage instructions).</p>
 
 					<h2>Rule execution hierarchy</h2>
-					<p>Specify the order in which you would like the tables taversed.<br><em>Default is filename, referrer, mime.</em></p>
-					<input type="text" id="rule_order" name="rule_order" value="" placeholder="filename, referrer, mime">
+					<p>Specify the order in which you would like the tables taversed.<br><em>Default is filename, uriPath, referrer, mime.</em></p>
+					<input type="text" id="rule_order" name="rule_order" value="" placeholder="filename, uriPath, referrer, mime">
 
 					<h2>Filetype &#8680; folder mapping</h2>
 					<table id="mime_mapping_table">
@@ -212,6 +212,16 @@
 						</tbody>
 					</table>
 					<p class="note">* Keywords are case-insensitive. Recommended basic usage is a single keyword per rule. Further guidelines are available on the "Usage instructions" page. The keyword is treated directly as a regular expression &mdash; feel free to experiment.</p>
+
+					<h2>URI path fragment&#8680; folder mapping</h2>
+					<table id="uriPath_mapping_table">
+						<thead>
+							<tr><th>URI path fragment</th><th></th><th>Destination folder</th><th></th></tr>
+						</thead>
+						<tbody>
+							<tr><td colspan="4"><button id="add_uriPath_route" class="btn"><strong>+</strong> Add new routing rule</button></td></tr>
+						</tbody>
+					</table>
 
 					<h2>Troubleshooting</h2>
 

--- a/src/options.js
+++ b/src/options.js
@@ -6,16 +6,18 @@ var g_inited;
 var optionsMaps = [
 	'dr_mime_map',
 	'dr_referrer_map',
-	'dr_filename_map'
+	'dr_filename_map',
+	'dr_uriPath_map'
 ];
 var optionsMapsData = [];
 
 function save_options() {
-	var maps = [{}, {}, {}];
+	var maps = [{}, {}, {}, {}];
 	var tables = [
 		document.getElementById('mime_mapping_table').getElementsByTagName('tbody')[0],
 		document.getElementById('referrer_mapping_table').getElementsByTagName('tbody')[0],
-		document.getElementById('filename_mapping_table').getElementsByTagName('tbody')[0]
+		document.getElementById('filename_mapping_table').getElementsByTagName('tbody')[0],
+		document.getElementById('uriPath_mapping_table').getElementsByTagName('tbody')[0]
 	];
 
 	for(var idx in tables) {
@@ -31,16 +33,17 @@ function save_options() {
 	chrome.storage.local.set({'dr_mime_map': JSON.stringify(maps[0])});
 	chrome.storage.local.set({'dr_referrer_map': JSON.stringify(maps[1])});
 	chrome.storage.local.set({'dr_filename_map': JSON.stringify(maps[2])});
+	chrome.storage.local.set({'dr_uriPath_map': JSON.stringify(maps[3])});
 
 
 	var order = document.getElementById('rule_order').value;
 	order = order.replace(/\s+/g, '');
-	order = order.split(',', 3);
+	order = order.split(',', 4);
 
-	['filename', 'referrer', 'mime'].every(function(item) {
+	['filename', 'referrer', 'mime', 'uriPath'].every(function(item) {
 		if(order.indexOf(item) == -1) {
-			alert('Invalid ruleset hierarchy, resetting to default.');
-			order = ['filename', 'referrer', 'mime'];
+			alert('Invalid ruleset hierarchy, resetting to default. Missing: ' + item);
+			order = ['filename', 'uriPath', 'referrer', 'mime'];
 			return false;
 		}
 
@@ -67,12 +70,13 @@ function save_options() {
 }
 
 function restore_options() {
-    chrome.storage.local.get(['dr_order', 'dr_filename_map', 'dr_referrer_map', 'dr_mime_map', 'dr_global_ref_folders', 'global_debugging'], function(items) {
+    chrome.storage.local.get(['dr_order', 'dr_filename_map', 'dr_referrer_map', 'dr_mime_map', 'dr_uriPath_map', 'dr_global_ref_folders', 'global_debugging'], function(items) {
 			g_dr_order = items.dr_order;
 
 			optionsMapsData[0]  = items.dr_mime_map;
 			optionsMapsData[1] = items.dr_referrer_map;
 			optionsMapsData[2] = items.dr_filename_map;
+			optionsMapsData[3] = items.dr_uriPath_map;
 
 			g_dr_global_ref_folders = items.dr_global_ref_folders;
 			g_dr_global_debugging   = items.global_debugging;
@@ -85,13 +89,15 @@ function restore_options_finish() {
 	var map_defaults = [
 		{ 'image/jpeg': 'images/', 'application/x-bittorrent': 'torrents/' },
 		{},
+		{},
 		{}
 	];
 
 	var tables = [
 		document.getElementById('mime_mapping_table').getElementsByTagName('tbody')[0],
 		document.getElementById('referrer_mapping_table').getElementsByTagName('tbody')[0],
-		document.getElementById('filename_mapping_table').getElementsByTagName('tbody')[0]
+		document.getElementById('filename_mapping_table').getElementsByTagName('tbody')[0],
+		document.getElementById('uriPath_mapping_table').getElementsByTagName('tbody')[0]
 	];
 
 	for(var idx = 0; idx < optionsMaps.length; ++idx) {
@@ -124,7 +130,7 @@ function restore_options_finish() {
 
 	var order = g_dr_order;
 	if (!order) {
-		order = ['filename', 'referrer', 'mime'];
+		order = ['filename', 'uriPath', 'referrer', 'mime'];
 		chrome.storage.local.set({'dr_order': order});
 	}
 
@@ -211,7 +217,7 @@ function add_referrer_route() {
 	var table             = document.getElementById('referrer_mapping_table').getElementsByTagName('tbody')[0];
 	var refInput          = document.createElement('input');
 	refInput.type         = 'text';
-	refInput.placeholder  = 'E.g. 9gag.com (no http://)';
+	refInput.placeholder  = 'E.g. google.com (no http://)';
 	var pathInput         = document.createElement('input');
 	pathInput.type        = 'text';
 	pathInput.placeholder = 'some/folder/';
@@ -229,6 +235,18 @@ function add_filename_route() {
 	pathInput.placeholder = 'some/folder/';
 
 	add_table_row(table, refInput, pathInput);
+}
+
+function add_uriPath_route() {
+	var table             = document.getElementById('uriPath_mapping_table').getElementsByTagName('tbody')[0];
+	var uriPathInput      = document.createElement('input');
+	uriPathInput.type        = 'text';
+	uriPathInput.placeholder = 'E.g. uploads';
+	var pathInput         = document.createElement('input');
+	pathInput.type        = 'text';
+	pathInput.placeholder = 'some/folder/';
+
+	add_table_row(table, uriPathInput, pathInput);
 }
 
 function options_setup() {
@@ -297,3 +315,4 @@ document.querySelector('#save').addEventListener('click', save_options);
 document.querySelector('#add_mime_route').addEventListener('click', add_mime_route);
 document.querySelector('#add_referrer_route').addEventListener('click', add_referrer_route);
 document.querySelector('#add_filename_route').addEventListener('click', add_filename_route);
+document.querySelector('#add_uriPath_route').addEventListener('click', add_uriPath_route);

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 var g_dr_order;
 var g_dr_global_ref_folders;
 var g_dr_global_debugging;
-
+var g_inited;
 
 var optionsMaps = [
 	'dr_mime_map',
@@ -232,13 +232,21 @@ function add_filename_route() {
 }
 
 function options_setup() {
+    chrome.storage.local.get(['dr_mime_map'], function(items) {
+			g_inited = items.dr_mime_map;
+
+			options_setup_callback();
+	});
+}
+
+function options_setup_callback() {
 	var cont   = document.getElementById('wrap');
 	var navs   = cont.querySelectorAll('ul#nav li');
 	var tabs   = cont.querySelectorAll('.tab');
 	var active = 'routing';
-/*
+
 	// Handle new installations by showing the usage instructions and a quick message
-	if(!localStorage.getItem('dr_mime_map')) {
+	if(!g_inited) {
 		active = 'usage';
 
 		var status = document.getElementById('status');
@@ -249,7 +257,7 @@ function options_setup() {
 			status.style.display = 'none';
 		}, 7500);
 	}
-*/
+
 	navs[0].parentNode.dataset.current = active;
 
 	for(var i = 0; i < tabs.length; i++) {


### PR DESCRIPTION
Chrome Manifest V3:
- Manifest updated (permissions, V2->V3 migration).
- Fixed minor JS syntax problems.
- Moved from using window.localStorage to Chrome's chrome.storage.local (and kept same functionality even with this async API).

Added optional console output support (new configuration option).
